### PR TITLE
Courses with null course level not being deleted

### DIFF
--- a/api/src/main/java/ca/bc/gov/educ/api/pen/replication/service/StudentCourseUpdateService.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/pen/replication/service/StudentCourseUpdateService.java
@@ -111,6 +111,7 @@ public class StudentCourseUpdateService extends BaseService<StudentCourseUpdate>
         traxStudentCourseEntity.getStudXcrseId().setCourseLevel(StringUtils.trimToNull(course.getExternalCode().substring(5)));
       }else{
         traxStudentCourseEntity.getStudXcrseId().setCourseCode(StringUtils.trimToNull(course.getExternalCode()));
+        traxStudentCourseEntity.getStudXcrseId().setCourseLevel(" ");
       }
     }else{
       log.info("No course was found for ID {} :: this should not have happened", courseID);


### PR DESCRIPTION
Hibernate will not return rows if one of the embedded id fields is null. Adding whitespace placeholder